### PR TITLE
Update from dotnet 7.0 (end of life) to 9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Lumafly-Windows
-        path: Lumafly/bin/Release/net7.0/win-x64/publish/
+        path: Lumafly/bin/Release/net9.0/win-x64/publish/
 
   build-linux:
     runs-on: ubuntu-latest
@@ -40,8 +40,8 @@ jobs:
         cd Lumafly
         dotnet publish -r linux-x64 -p:PublishSingleFile=true -p:Configuration=Release --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=embedded
         cd ..
-        chmod +x Lumafly/bin/Release/net7.0/linux-x64/publish/Lumafly
-        zip -jr linux.zip Lumafly/bin/Release/net7.0/linux-x64/publish/*
+        chmod +x Lumafly/bin/Release/net9.0/linux-x64/publish/Lumafly
+        zip -jr linux.zip Lumafly/bin/Release/net9.0/linux-x64/publish/*
     - name: Upload linux binary
       uses: actions/upload-artifact@v3
       with:
@@ -64,7 +64,7 @@ jobs:
         dotnet publish -r osx-x64 -p:PublishSingleFile=true -p:Configuration=Release --self-contained true
         cd ..
         cd Scripts
-        python3 make_mac_app.py Lumafly.app ../Lumafly/bin/Release/net7.0/osx-x64/publish ../out
+        python3 make_mac_app.py Lumafly.app ../Lumafly/bin/Release/net9.0/osx-x64/publish ../out
         cd ..
     - name: Upload macos binary
       uses: actions/upload-artifact@v3
@@ -104,7 +104,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Lumafly-AU
-        path: Lumafly.AU/bin/Release/net7.0/win-x64/publish/
+        path: Lumafly.AU/bin/Release/net9.0/win-x64/publish/
 
 
   release:

--- a/Lumafly.AU/Lumafly.AU.csproj
+++ b/Lumafly.AU/Lumafly.AU.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RootNamespace>Lumafly.AU</RootNamespace>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/Lumafly.AU/publish.bat
+++ b/Lumafly.AU/publish.bat
@@ -6,4 +6,4 @@ if not exist "%~dp0out\*" (
     del /Q /F "%~dp0out\*"
 )
 
-copy "%~dp0bin\Release\net7.0\win-x64\publish\Lumafly.AU.exe" "%~dp0out\Lumafly.AU.exe"
+copy "%~dp0bin\Release\net9.0\win-x64\publish\Lumafly.AU.exe" "%~dp0out\Lumafly.AU.exe"

--- a/Lumafly.Tests/Lumafly.Tests.csproj
+++ b/Lumafly.Tests/Lumafly.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Lumafly/Lumafly.csproj
+++ b/Lumafly/Lumafly.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <!-- Windowed exe, avoids Console showing for users. -->
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <LangVersion>preview</LangVersion>
         <Nullable>enable</Nullable>
         <ApplicationIcon>Assets/Lumafly.ico</ApplicationIcon>

--- a/Scripts/publish.bat
+++ b/Scripts/publish.bat
@@ -7,7 +7,7 @@ if not exist "%~dp0\..\out\*" (
 cd ../Lumafly
 
 dotnet publish -r win-x64 -p:PublishSingleFile=true -p:Configuration=Release --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=embedded
-copy "%~dp0\..\Lumafly\bin\Release\net7.0\win-x64\publish\Lumafly.exe" "%~dp0\..\out\Lumafly.exe"
+copy "%~dp0\..\Lumafly\bin\Release\net9.0\win-x64\publish\Lumafly.exe" "%~dp0\..\out\Lumafly.exe"
 
 dotnet publish -r linux-x64 -p:Configuration=Release -p:PublishSingleFile=true -p:UseAppHost=true --self-contained true -p:AppendTargetFrameworkToOutputPath=false -p:OutputPath=bin\$(Configuration)\$(Platform)\ControlCatalog.NetCore.app/Contents/MacOS
 dotnet publish -r osx-x64 -p:Configuration=Release -p:PublishSingleFile=true -p:UseAppHost=true --self-contained true
@@ -15,8 +15,8 @@ dotnet publish -r osx-x64 -p:Configuration=Release -p:PublishSingleFile=true -p:
 cd ..
 
 cd Scripts
-python make_mac_app.py Lumafly.app ../Lumafly/bin/Release/net7.0/osx-x64/publish ../out
+python make_mac_app.py Lumafly.app ../Lumafly/bin/Release/net9.0/osx-x64/publish ../out
 cd ..
 
-7z a "out/windows.zip" "./Lumafly/bin/Release/net7.0/win-x64/publish/*"
-7z a "out/linux.zip" "./Lumafly/bin/Release/net7.0/linux-x64/publish/*"
+7z a "out/windows.zip" "./Lumafly/bin/Release/net9.0/win-x64/publish/*"
+7z a "out/linux.zip" "./Lumafly/bin/Release/net9.0/linux-x64/publish/*"


### PR DESCRIPTION
[.NET 7 is end of life](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) so this PR updates the target framework to 9.0.

This also fixes the [Lumafly Nix package](https://search.nixos.org/packages?show=lumafly) since it currently fails to build due to this issue.