### PR TITLE
improve steam detection

### DIFF
--- a/Lumafly/ViewModels/InfoViewModel.cs
+++ b/Lumafly/ViewModels/InfoViewModel.cs
@@ -82,9 +82,8 @@ public partial class InfoViewModel : ViewModelBase
 
             var exeDetails = GetExecutableDetails();
 
-            if (exeDetails.name is hollow_knight or hollow_knight + ".exe")
+            if (exeDetails.isSteam)
             {
-                // assumption: hollow_knight is only used in steam. So might as well make steam run it
                 Process.Start(new ProcessStartInfo("steam://rungameid/367520")
                 {
                     UseShellExecute = true
@@ -109,7 +108,7 @@ public partial class InfoViewModel : ViewModelBase
         IsLaunchingGame = false;
     }
 
-    private (string path, string name) GetExecutableDetails()
+    private (string path, string name, bool isSteam) GetExecutableDetails()
     {
         string exeName;
         
@@ -139,8 +138,15 @@ public partial class InfoViewModel : ViewModelBase
 
         if (hkExeFolder is null) throw new Exception("Hollow Knight executable not found");
         string exePath = hkExeFolder.FullName;
+        
+        // check if path contains steam_api64.dll
+        var x86_64Folder = managedParent?
+            .GetDirectories().FirstOrDefault(d => d.Name == "Plugins")?
+            .GetDirectories().FirstOrDefault(d => d.Name == "x86_64");
+        
+        var isSteam = x86_64Folder?.GetFiles("steam_api64.dll").Any() ?? false;
 
-        return (exePath, exeName);
+        return (exePath, exeName, isSteam);
     }
 
     public async Task FetchAdditionalInfo()

--- a/Lumafly/ViewModels/InfoViewModel.cs
+++ b/Lumafly/ViewModels/InfoViewModel.cs
@@ -140,12 +140,13 @@ public partial class InfoViewModel : ViewModelBase
         string exePath = hkExeFolder.FullName;
         
         // check if path contains steam_api64.dll
-        var x86_64Folder = managedParent?
-            .GetDirectories().FirstOrDefault(d => d.Name == "Plugins")?
-            .GetDirectories().FirstOrDefault(d => d.Name == "x86_64");
+        var isSteam = File.Exists(Path.Combine(
+            managedParent.FullName,
+            "Plugins",
+            "x86_64",
+            "steam_api64.dll"
+        ));
         
-        var isSteam = x86_64Folder?.GetFiles("steam_api64.dll").Any() ?? false;
-
         return (exePath, exeName, isSteam);
     }
 


### PR DESCRIPTION
changed steam detection by checking if steam_api64.dll exists, instead of relying on the spelling of the .exe, to fix  #145 

in corporation with @flyingbaum and @Git-Student1