### PR TITLE
Add default launch arguments feature for GOG/non-steam players

### DIFF
--- a/Lumafly/Resources.resx
+++ b/Lumafly/Resources.resx
@@ -735,4 +735,7 @@
   <data name="XAML_Modlog" xml:space="preserve">
     <value>Open ModLog.txt</value>
   </data>
+  <data name="XAML_LaunchArguments" xml:space="preserve">
+    <value>Launch Arguments</value>
+  </data>
 </root>

--- a/Lumafly/Services/Interfaces/ISettings.cs
+++ b/Lumafly/Services/Interfaces/ISettings.cs
@@ -23,6 +23,7 @@ namespace Lumafly.Interfaces
 
         string GithubMirrorFormat { get; set; }
         bool UseGithubMirror { get; set; }
+        string LaunchArgs { get; set; }
 
         void Save();
     }

--- a/Lumafly/Settings.cs
+++ b/Lumafly/Settings.cs
@@ -36,6 +36,7 @@ namespace Lumafly
         [JsonConverter(typeof(JsonStringEnumConverter))]
         public SupportedLanguages? PreferredLanguage { get; set; }
         public bool LowStorageMode { get; set; } = false;
+        public string LaunchArgs { get; set; } = string.Empty;
         public string ExtraSpaceTaken
         {
             get

--- a/Lumafly/ViewModels/InfoViewModel.cs
+++ b/Lumafly/ViewModels/InfoViewModel.cs
@@ -94,6 +94,7 @@ public partial class InfoViewModel : ViewModelBase
                 Process.Start(new ProcessStartInfo
                 {
                     FileName = exeDetails.name,
+                    Arguments=_settings.LaunchArgs,
                     WorkingDirectory = exeDetails.path,
                     UseShellExecute = true,
                 });

--- a/Lumafly/ViewModels/SettingsViewModel.cs
+++ b/Lumafly/ViewModels/SettingsViewModel.cs
@@ -137,6 +137,17 @@ namespace Lumafly.ViewModels
                 RaisePropertyChanged(nameof(AskForReload));
             }
         }
+        
+        public string LaunchArgs
+        {
+            get => _settings.LaunchArgs;
+            set
+            {
+                _settings.LaunchArgs = value;
+                _settings.Save();
+                RaisePropertyChanged(nameof(LaunchArgs));
+            }
+        }
 
         public string ExtraSpaceTaken => string.Format(Resources.XAML_CacheDownloads_Explanation, _settings.ExtraSpaceTaken);
         

--- a/Lumafly/Views/Pages/SettingsView.axaml
+++ b/Lumafly/Views/Pages/SettingsView.axaml
@@ -15,7 +15,7 @@
 			ShowGridLines="False"
 			Margin="20 10"
 			ColumnDefinitions="Auto * Auto"
-			RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto *">
+			RowDefinitions="Auto Auto Auto Auto Auto Auto Auto Auto Auto Auto *">
 			
 			<TextBlock
 				Grid.Column="0"
@@ -193,6 +193,25 @@
 				Watermark="{ext:Localize XAML_GithubMirrorFormatWatermark}"
 				UseFloatingWatermark="True"
 				Text="{Binding GithubMirrorFormat}"
+				AcceptsReturn="False"/>
+			
+			<TextBlock
+				Grid.Column="0"
+				Grid.Row="9"
+				Margin="0 15"
+				VerticalAlignment="Center"
+				Text="{ext:Localize XAML_LaunchArguments}"/>
+
+			<TextBox
+				Grid.Column="1"
+				Grid.ColumnSpan="2"
+				Grid.Row="9"
+				Margin="0 0 5 15"
+				HorizontalAlignment="Stretch"
+				VerticalAlignment="Center"
+				Watermark="{ext:Localize XAML_LaunchArguments}"
+				UseFloatingWatermark="True"
+				Text="{Binding LaunchArgs}"
 				AcceptsReturn="False"/>
 
 			<Grid

--- a/Lumafly/Views/Pages/SettingsView.axaml
+++ b/Lumafly/Views/Pages/SettingsView.axaml
@@ -206,7 +206,7 @@
 				Grid.Column="1"
 				Grid.ColumnSpan="2"
 				Grid.Row="9"
-				Margin="0 0 5 15"
+				Margin="10 0 5 0"
 				HorizontalAlignment="Stretch"
 				VerticalAlignment="Center"
 				Watermark="{ext:Localize XAML_LaunchArguments}"

--- a/Lumafly/resources.Designer.cs
+++ b/Lumafly/resources.Designer.cs
@@ -1903,5 +1903,14 @@ namespace Lumafly {
                 return ResourceManager.GetString("XAML_WarnBeforeRemovingDependentMods", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Specify the launch args for the game
+        /// </summary>
+        internal static string XAML_LaunchArguments {
+            get {
+                return ResourceManager.GetString("XAML_LaunchArguments", resourceCulture);
+            }
+        }
     }
 }


### PR DESCRIPTION
Preview:
<img width="947" height="659" alt="image" src="https://github.com/user-attachments/assets/bd51a465-77cf-495c-bade-976d2c9dca10" />

This feature is very necessary especially for NVIDIA Linux players whom GPU doesn't support Vulkan (Like some issues from Pale Court mod: https://github.com/PaleCourt/PaleCourt/issues/40 or https://forums.developer.nvidia.com/t/games-freeze-after-a-few-minutes-of-playing-in-menu-or-while-playing-on-steam-with-prime-offloading-and-x-server-21-1-4-1/240150. They have to use `-force-opengl` to fix this).

Note that this is for non-Steam players as Steam also has the arguments option so we should not worry about it.

Quite sorry to all of the translators as for now they have to start translating the text `Launch Arguments` to their languages.